### PR TITLE
Improve: Slight changes in handling of extra moa jumps

### DIFF
--- a/src/main/java/com/aetherteam/protect_your_moa/client/renderer/ProtectOverlays.java
+++ b/src/main/java/com/aetherteam/protect_your_moa/client/renderer/ProtectOverlays.java
@@ -38,8 +38,7 @@ public class ProtectOverlays {
 
     private static void renderMoaJumps(GuiGraphics guiGraphics, Window window, LocalPlayer player) {
         if (player.getVehicle() instanceof Moa moa) {
-            MoaType moaType = moa.getMoaType();
-            int jumps = moaType != null ? moaType.getMaxJumps() : AetherMoaTypes.BLUE.get().getMaxJumps();
+            int jumps = moa.getMaxJumps()-3;
             LazyOptional<MoaArmor> moaArmorLazyOptional = MoaArmor.get(moa);
             if (moaArmorLazyOptional.isPresent()) {
                 Optional<MoaArmor> moaArmorOptional = moaArmorLazyOptional.resolve();

--- a/src/main/java/com/aetherteam/protect_your_moa/mixin/mixins/client/AetherOverlaysMixin.java
+++ b/src/main/java/com/aetherteam/protect_your_moa/mixin/mixins/client/AetherOverlaysMixin.java
@@ -22,8 +22,7 @@ import java.util.Optional;
 public class AetherOverlaysMixin {
     @Inject(at = @At(value = "INVOKE", target = "Lcom/mojang/blaze3d/platform/Window;getGuiScaledWidth()I", shift = At.Shift.BEFORE), method = "renderMoaJumps(Lnet/minecraft/client/gui/GuiGraphics;Lcom/mojang/blaze3d/platform/Window;Lnet/minecraft/client/player/LocalPlayer;)V", cancellable = true, remap = false)
     private static void renderMoaJumps(GuiGraphics guiGraphics, Window window, LocalPlayer player, CallbackInfo ci, @Local Moa moa, @Local(ordinal = 0) int jumpCount) {
-        MoaType moaType = moa.getMoaType();
-        int jumps = moaType != null ? moaType.getMaxJumps() : AetherMoaTypes.BLUE.get().getMaxJumps();
+        int jumps = moa.getMaxJumps()-3;
         LazyOptional<MoaArmor> moaArmorLazyOptional = MoaArmor.get(moa);
         if (moaArmorLazyOptional.isPresent()) {
             Optional<MoaArmor> moaArmorOptional = moaArmorLazyOptional.resolve();

--- a/src/main/java/com/aetherteam/protect_your_moa/mixin/mixins/common/MoaMixin.java
+++ b/src/main/java/com/aetherteam/protect_your_moa/mixin/mixins/common/MoaMixin.java
@@ -5,30 +5,28 @@ import com.aetherteam.aether.api.registers.MoaType;
 import com.aetherteam.aether.entity.passive.Moa;
 import com.aetherteam.protect_your_moa.capability.armor.MoaArmor;
 import com.aetherteam.protect_your_moa.item.ProtectItems;
+import com.llamalad7.mixinextras.injector.ModifyReturnValue;
 import net.minecraftforge.common.util.LazyOptional;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import java.util.Optional;
 
 @Mixin(Moa.class)
 public class MoaMixin {
-    @Inject(at = @At(value = "HEAD"), method = "getMaxJumps()I", cancellable = true, remap = false)
-    private void getMaxJumps(CallbackInfoReturnable<Integer> cir) {
+    @ModifyReturnValue(at = @At(value = "RETURN"), method = "getMaxJumps()I", remap = false)
+    private int getMaxJumps(int original) {
         Moa moa = (Moa) (Object) this;
-        MoaType moaType = moa.getMoaType();
-        int jumps = moaType != null ? moaType.getMaxJumps() : AetherMoaTypes.BLUE.get().getMaxJumps();
         LazyOptional<MoaArmor> moaArmorLazyOptional = MoaArmor.get(moa);
         if (moaArmorLazyOptional.isPresent()) {
             Optional<MoaArmor> moaArmorOptional = moaArmorLazyOptional.resolve();
             if (moaArmorOptional.isPresent()) {
                 MoaArmor moaArmor = moaArmorOptional.get();
                 if (moaArmor.getArmor() != null && moaArmor.getArmor().is(ProtectItems.GRAVITITE_MOA_ARMOR.get())) {
-                    cir.setReturnValue(jumps + 3);
+                    return original + 3;
                 }
             }
         }
+        return original;
     }
 }


### PR DESCRIPTION
This pr changes the inject method of getMaxJumps inside the MoaMixin class into a more compatible ModifyReturnValue statement from mixinextra. This is to allow other addons to also modify a Moa's maximum amount of jumps in a compatible way, for example deep aether adds a mob effect that allows the maximum numbers of moa jumps to be increased.

For similar reasons this pr also changes the calculations of the amount of gravitite jump feathers being displayed inside of the ProtectOverlays and AetherOverlaysMixin classes. This is because those calculations wouldn't could in for any additional moa jumps added by other addons, which would cause too many gravitite feathers to be displayed relative to normal feathers.  

I agree to the Contributor License Agreement (CLA).